### PR TITLE
Add invite URL generator docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS Instructions
+
+## Testing
+
+Para validar que la libreria compila correctamente ejecuta:
+
+```
+npm run build
+```
+
+No deberian aparecer errores. Si hay errores, corrige el código antes de enviar PR.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,6 +36,9 @@ const plugins = [
                 items: [{
                     label: 'Translator',
                     slug: 'guides/services/translator',
+                }, {
+                    label: 'Invite URL generator',
+                    slug: 'guides/services/invite-url-generator',
                 }],
             }, {
                 label: 'Other',

--- a/src/content/docs/guides/services/invite-url-generator.mdx
+++ b/src/content/docs/guides/services/invite-url-generator.mdx
@@ -1,0 +1,22 @@
+---
+title: Invite URL generator
+description: Use the InviteUrlGenerator service to create links for inviting your bot.
+---
+
+The `InviteUrlGenerator` service provides a helper to easily create the Discord OAuth2 URL needed to invite your bot to a server.
+
+First obtain the service instance from the `ServiceContainer`:
+```ts
+import { ServiceContainer } from 'zumito-framework';
+import { InviteUrlGenerator } from 'zumito-framework';
+
+const inviteGenerator = ServiceContainer.getService(InviteUrlGenerator);
+```
+
+Once you have the service you can call `generateBotInviteUrl(clientId?, permissions?)`.
+Both parameters are optional; when `clientId` is omitted the value of `process.env.DISCORD_CLIENT_ID` will be used. If `permissions` is not provided it defaults to `0`.
+
+```ts
+const url = inviteGenerator.generateBotInviteUrl();
+// https://discord.com/api/oauth2/authorize?client_id=...&permissions=0&scope=bot
+```


### PR DESCRIPTION
## Summary
- document the `InviteUrlGenerator` service
- link it in the guides sidebar
- add AGENTS instructions for running tests

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685009983680832fb0e4edd068cfd7b4