### PR TITLE
Add Spanish translations for guides

### DIFF
--- a/src/content/docs/es/guides/bot-status.mdx
+++ b/src/content/docs/es/guides/bot-status.mdx
@@ -1,0 +1,37 @@
+---
+title: Actualizar el estado del bot
+description: Guía rápida sobre cómo actualizar el estado del bot
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Opciones de estado de ejemplo
+
+```diff lang="js"
+// src/Bot.ts
+    new ZumitoFramework({
+        ...
++       statusOptions: {
++           statuses: [{
++               status: 'online',
++               activities: [{
++                   name: 'z-help',
++                   type: ActivityType.Playing
++               }]
++           }],
++           RuledStatuses: [],
++           updateInterval: 15000,
++           order: "sequential"
++       },
+    });
+```
+
+### statuses
+Un array con la lista de estados que mostrará el bot
+Cada estado tiene estas propiedades:
+- status: online, dnd, offline,
+- activities:
+    - name: Nombre a mostrar. Se mostrará como: Playing z-help
+    - type: Tipo de actividad
+- updateInterval: Cada cuántos milisegundos cambiará el estado el bot
+- order: ¿En qué orden irá cambiando la lista de estados? secuencial o aleatorio

--- a/src/content/docs/es/guides/command.mdx
+++ b/src/content/docs/es/guides/command.mdx
@@ -1,0 +1,217 @@
+---
+title: Crear comando
+description: Guía rápida sobre cómo crear un comando.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
+
+Para empezar a crear un comando sigue estos pasos:
+<Steps>
+    1. Ejecuta el siguiente comando para crear el archivo y el código inicial:
+        ```bash
+        npx zumito-cli create command
+        ```
+
+    2. Te preguntará el nombre del comando y el módulo donde deseas crearlo.
+        <Aside>
+            No te preocupes si todavía no has creado el módulo, la CLI lo creará por ti.
+        </Aside>
+
+    3. Después de esto se creará un archivo en `src/modules/<module>/commands` con el nombre del comando.
+        El archivo contendrá el siguiente código:
+        ```ts
+        import { Command, CommandParameters, ZumitoFramework, CommandType, SelectMenuParameters } from "zumito-framework";
+
+        export class CommandName extends Command {
+
+            async execute({ message, interaction, args, guildSettings }: CommandParameters): Promise<void> {
+                // Código del comando
+            }
+
+            async selectMenu({ path, interaction, guildSettings }: SelectMenuParameters): Promise<void> {
+
+            }
+
+        }
+        ```
+        :::note
+            [aquí](#command-code) puedes encontrar información sobre cómo escribir el código del comando
+        :::
+
+</Steps>
+## Command code
+Aquí puedes escribir el código que ejecutará el bot cuando el usuario lance el comando
+<Tabs>
+    <TabItem label="Slash command" icon="cli">
+    ```ts
+        async executeSlashCommand({ interaction, args, guildSettings }: CommandParameters): Promise<void> {
+            // Este código se ejecutará cuando se use el comando por slash
+            interaction.reply({
+                content: "Test message",
+            })
+        }
+    ```
+    </TabItem>
+    <TabItem label="Prefix command" icon="wizard">
+    ```ts
+        async executePrefixCommand({ message, args, guildSettings }: CommandParameters): Promise<void> {
+            // Este código se ejecutará cuando se use el comando por prefijo
+            message.reply({
+                content: "Test message",
+            })
+        }
+    ```
+    </TabItem>
+    <TabItem label="Both commands" icon="wizard">
+    ```ts
+        async execute({ message, interaction, args, guildSettings }: CommandParameters): Promise<void> {
+            // Este código se ejecutará tanto para slash como para prefijo
+            (message||interaction).reply({
+                content: "Test message",
+            })
+        }
+    ```
+    </TabItem>
+</Tabs>
+
+:::note
+- Si ejecutas el comando por slash primero se intentará ejecutar la función `executeSlashCommand`. Si no existe se ejecutará la función `execute`.
+- Si ejecutas el comando por prefijo primero se intentará ejecutar `executePrefixCommand`. Si no existe se ejecutará `execute`.
+
+Así que, si deseas ejecutar código diferente en cada sistema puedes definir el código para cada uno, pero si el código es el mismo puedes escribirlo todo en `execute`.
+:::
+
+:::tip
+Puedes encontrar una mejor explicación de los parámetros que recibe la función execute en la sección [Execute parameters](#execute-parameters).
+:::
+
+## Execute parameters
+
+La función `execute` recibe un objeto `CommandParameters` que contiene las siguientes propiedades:
+- `message` - Objeto Discord.Message. Undefined si el comando se ejecuta desde una interacción (slash).
+- `interaction` - Objeto Discord.Interaction. Undefined si el comando se ejecuta desde un mensaje con el prefijo.
+- `args` - Argumentos del comando. Contiene los argumentos que el usuario pasó al comando.
+
+    - Puedes obtener los argumentos usando el método `get`, que recibe el nombre y el tipo del argumento.
+
+        ```ts
+        args.get("argumentName"); // Output: "Argument value"
+        ```
+    - La salida viene en el tipo que especifiques, así que si indicas un número obtendrás un número y si indicas un usuario obtendrás un objeto Discord.User.
+- `guildSettings` - Objeto de configuración de la guild. Contiene la configuración de la guild donde se ejecutó el comando. Los datos se cargan de la base de datos en cada ejecución.
+- `trans` - Función abreviada para traducir cadenas. Recibe la clave de la cadena y las variables a reemplazar.
+    - No requiere especificar el idioma, usará el idioma de la guild donde se ejecutó el comando.
+    - La clave es relativa al comando actual, por lo que si tienes una clave llamada `command.yourCommandName.yourKey`, puedes usarla así: `trans("yourKey")`. Si quieres usar una clave de otro lugar puedes usar el prefijo `$`, por ejemplo: `trans("$command.yourCommandName.yourKey")`.
+
+## Command atributes
+En la cabecera de tu clase de comando puedes definir algunos atributos. Aquí una breve descripción de cada uno.
+
+- `adminOnly`: true/false. Define si el comando solo puede ser usado por administradores de la guild o por cualquier usuario. Por defecto cualquier usuario (false)
+- `aliases`: array de strings. Define alias alternativos para el comando.
+- `args`: array de [CommandArgDefinition](https://tsdocs.dev/docs/zumito-framework/latest/interfaces/CommandArgDefinition.html). Define los parámetros que el usuario puede utilizar en el comando.
+- `binds`: [CommandBinds](https://tsdocs.dev/docs/zumito-framework/latest/types/CommandBinds.html) object. Define escuchas de eventos relacionados con el comando. Aquí puedes escuchar interacciones de select menu, envío de formularios, etc.
+- `botPermissions`: WIP
+- `categories`: array de strings. Define las categorías del comando. Úfil para el comando de ayuda.
+- `cooldown`: WIP
+- `dm`: true/false. Define si el comando puede ejecutarse en un canal privado. Por defecto false.
+    :::caution
+        Recuerda que en un DM no puedes acceder a las propiedades de la guild.
+    :::
+- `examples`: array de strings. Define ejemplos de uso del bot. Para un comando `clean` con un primer argumento numérico puedes escribir `['clean 100']`. No escribas ningún prefijo.
+- `hidden`: true/false. Define si el comando estará oculto en los comandos de ayuda. El comando seguirá siendo usable.
+- `name`: Define un nombre alternativo si no quieres usar el nombre de la clase.
+- `nsfw`: true/false. Define si el comando puede ejecutarse fuera de un canal nsfw. Por defecto false (el comando puede usarse en cualquier lugar)
+- `parent`: string. Comando padre. Úfil para subcomandos. WIP.
+- `type`: [CommandType](https://tsdocs.dev/docs/zumito-framework/latest/variables/CommandType.html) object. Define si el comando puede ejecutarse usando slash y/o prefijo.
+    CommandType.slash / CommandType.prefix / CommandType.any
+# Tips
+## Acces to discord client instance
+Para obtener la instancia de discord.js necesitas realizar unos pasos sencillos:
+<Steps>
+  1. Importa `ServiceContainer` de `zumito-framework` y `Client` de `zumito-framework/discord`
+        ```diff lang="js" ins="ServiceContainer, "
+            import { ServiceContainer, Command, CommandParameters, ZumitoFramework, CommandType, SelectMenuParameters } from "zumito-framework";
+        +   import { Client } from 'zumito-framework/discord';
+            export class CommandName extends Command {
+                ...
+            }
+        ```
+
+  2. Define la variable dentro de la clase
+        ```diff lang="ts"
+            export class CommandName extends Command {
+        +       private client: Client;
+            }
+        ```
+
+  3. Inicializa la variable obteniéndola del ServiceContainer:
+        ```diff lang="ts"
+            export class CommandName extends Command {
+                private client: Client;
+        +       constructor() {
+        +           super();
+        +           this.client = ServiceContainer.get(Client);
+        +       }
+            }
+        ```
+  4. Ahora puedes usar el cliente en cualquier parte del comando:
+        ```diff lang="ts"
+            export class CommandName extends Command {
+                private client: Client;
+                constructor() {
+                    super();
+                    this.client = ServiceContainer.get(Client);
+                }
+
+        +       async execute(params): Promise<void> {
+        +           console.log(this.client.status);
+        +       }
+            }
+        ```
+</Steps>
+
+:::tip[Did you know?]
+Puedes simplificar el código inicializando en los parámetros del constructor:
+```ts
+constructor(
+    private client: Client = ServiceContainer.get(Client)
+) {
+    super();
+}
+```
+:::
+
+## Read command args
+El parámetro `args` de la función `execute` contiene los argumentos que el usuario pasó al comando.
+Puedes obtenerlos con el método `get`, que recibe el nombre del argumento y su tipo.
+
+<Tabs>
+    <TabItem label="Text arg">
+        ```diff lang=ts
+        async execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): Promise<void> {
+        +   const textArg: string = args.get("argumentName"); // Output: "Argument value"
+        }
+        ```
+        Output: String
+    </TabItem>
+    <TabItem label="User arg">
+        ```diff lang=ts
+        async execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): Promise<void> {
+        +   const userArg: User =  args.get("argumentName");
+        }
+        ```
+        Output: [User](https://discord.js.org/docs/packages/discord.js/main/User:Class)
+    </TabItem>
+    <TabItem label="Channel arg">
+        ```diff lang=ts
+        async execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): Promise<void> {
+        +   const channelArg: GuildChannel =  args.get("argumentName");
+        }
+        ```
+        Output: [GuildChannel](https://discord.js.org/docs/packages/discord.js/main/GuildChannel:Class)
+    </TabItem>
+
+
+</Tabs>

--- a/src/content/docs/es/guides/env.mdx
+++ b/src/content/docs/es/guides/env.mdx
@@ -1,0 +1,37 @@
+---
+title: Variables de entorno
+description: Guía para las variables de entorno
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Aquí puedes encontrar todos los parámetros que se pueden definir en archivos `.env` o variables de entorno. Normalmente establecemos aquí variables que pueden diferir entre ambientes (producción, desarrollo, CI, etc.) como tokens o dominios de APIs.
+
+## Discord variables
+
+- **DISCORD_TOKEN**: Token del bot de Discord
+- **DISCORD_CLIENT_ID**: ID pública del bot
+- **DISCORD_CLIENT_SECRET**: Clave secreta privada del bot
+
+## Database variables
+
+Dependiendo de la base de datos utilizada podemos definir estas variables
+
+### MYSQL / PostgreSQL
+
+- **DATABASE_HOST**: IP o dominio donde se encuentra la base de datos
+- **DATABASE_PORT** Puerto en el que la base de datos está escuchando. Comúnmente 3306 para MySQL o 5432 para PostgreSQL
+- **DATABASE_USERNAME**: Usuario de la base de datos
+- **DATABASE_PASSWORD**: Contraseña de la base de datos
+- **DATABASE_NAME**: Nombre de la base de datos
+
+### MongoDB
+
+- **DATABASE_URI**: Cadena de conexión de la base de datos
+
+## Other variables
+
+Aquí puedes encontrar variables de todo tipo
+
+- **BOT_PREFIX**: Prefijo para comandos por prefijo. Se usará como prefijo por defecto/alternativo. Útil si necesitas distintos prefijos entre tu bot local y de producción
+- **SECRET_KEY**: Puede ser cualquier cadena de texto. Es como una contraseña. Se utilizará para cifrar datos como los tokens JWT en la API.

--- a/src/content/docs/es/guides/event.mdx
+++ b/src/content/docs/es/guides/event.mdx
@@ -1,0 +1,69 @@
+---
+title: Escuchar un evento
+description: Guía rápida sobre cómo crear un evento.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Los eventos se utilizan para escuchar acciones emitidas por distintas fuentes como el cliente de Discord o el propio framework de Zumito. Esto permite ejecutar código cuando se produce un evento específico.
+
+Para comenzar a escuchar un evento solo necesitas ejecutar el siguiente comando:
+
+```bash
+npx zumito-cli create event
+```
+
+Te preguntará el nombre del evento y el módulo donde quieres crearlo.
+
+<Aside>
+    No te preocupes si todavía no creaste el módulo, la CLI lo creará por ti.
+</Aside>
+
+Tras esto se creará un archivo en `src/modules/<module>/events` con el nombre del evento.
+
+El archivo contendrá el siguiente código:
+
+```ts
+import { FrameworkEvent, EventParameters } from 'zumito-framework';
+
+export class EventName extends FrameworkEvent {
+
+    once = false;
+    source = 'discord'
+
+    async execute({ interaction, client, framework, }: EventParameters): Promise<void> {
+        // Código del evento
+    }
+
+}
+```
+
+Para empezar a definir el evento necesitamos establecer la propiedad `once`. Esta propiedad indica si el evento se ejecutará solo una vez o cada vez que se emita.
+
+Ahora definamos un ejemplo para el evento `interactionCreate`.
+Primero estableceremos la propiedad `once` en `false` ya que queremos que se ejecute cada vez que se emita el evento:
+
+```ts
+once = false;
+```
+
+Luego definiremos la propiedad `source` en `discord` ya que queremos escuchar un evento de Discord. Para otros casos podemos escuchar otras fuentes como `framework`:
+
+```ts
+source = 'discord';
+```
+
+Ahora necesitamos definir la función `execute`. Esta función se ejecutará cada vez que se emita el evento.
+La función `execute` recibe un objeto `EventParameters` con las siguientes propiedades:
+- `message` - El mensaje que desencadenó el evento. Solo disponible para `messageCreate`.
+- `interaction` - La interacción que desencadenó el evento. Solo disponible para `interactionCreate`.
+- `client` - La instancia de Discord.js.
+- `framework` - La instancia de Zumito Framework.
+
+Por último definamos el código del evento:
+
+```ts
+async execute({ interaction, client, framework, }: EventParameters): Promise<void> {
+    interaction.reply('Hello world!');
+}
+```

--- a/src/content/docs/es/guides/index.mdx
+++ b/src/content/docs/es/guides/index.mdx
@@ -1,0 +1,5 @@
+---
+title: Índice de guías
+description: Un índice de guías en la documentación de Zumito
+topic: guides
+---

--- a/src/content/docs/es/guides/model.mdx
+++ b/src/content/docs/es/guides/model.mdx
@@ -1,0 +1,118 @@
+---
+title: Crear modelo de base de datos
+description: Guía rápida sobre cómo crear un modelo de base de datos.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Los modelos de base de datos se utilizan para definir la estructura de los datos que se almacenarán. Esto te permite definir qué datos guardará tu módulo en la base de datos.
+En cada modelo definimos todas las propiedades con sus tipos y las respectivas relaciones con otros modelos.
+
+Para comenzar a crear un modelo solo necesitas ejecutar el siguiente comando:
+
+```bash
+npx zumito-cli create model
+```
+
+Te preguntará el nombre del modelo y el módulo donde quieres crearlo.
+
+<Aside>
+    No te preocupes si todavía no has creado el módulo, la CLI lo hará por ti.
+</Aside>
+
+Tras esto se creará un archivo en `src/modules/<module>/models` con el nombre del modelo.
+El archivo contendrá el siguiente código:
+
+```ts
+import { DatabaseModel } from '../../types/DatabaseModel.js';
+
+export class Guild extends DatabaseModel {
+    getModel(schema: any) {
+        return {}
+    }
+
+    define(model: any, models: any): void {
+
+    }
+}
+```
+
+Para comenzar a definir el modelo necesitas establecer las propiedades en la función `getModel`.
+La función `getModel` recibe un objeto `schema` que contiene los tipos disponibles para definir las propiedades del modelo.
+- `schema.String` - Define una propiedad de tipo string.
+- `schema.Number` - Define una propiedad numérica.
+- `schema.Boolean` - Define una propiedad booleana.
+- `schema.Date` - Define una propiedad de fecha.
+- `schema.Blob` - Define una propiedad blob.
+- `schema.JSON` - Define una propiedad JSON.
+
+Ahora definamos un modelo de ejemplo para un usuario.
+Primero en la función `getModel` definiremos las propiedades del modelo:
+
+```ts
+getModel(schema: any) {
+    return {
+        username: {
+            type: schema.String,
+            required: true
+        },
+        age: {
+            type: schema.Number,
+            required: true
+        },
+        lang: {
+            type: schema.String,
+            default: 'en',
+        },
+        isPremium: {
+            type: schema.Boolean,
+            required: true,
+            default: false
+        },
+        createdAt: {
+            type: schema.Date,
+            required: true,
+        }
+    }
+}
+```
+
+Luego, en la función `define`, podemos definir validaciones y relaciones con otros modelos.
+
+```ts
+define(model: any, models: any): void {
+
+        // Definir validaciones
+        model.validatesUniquenessOf('username');
+        model.validatesInclusionOf('lang', { in: ['en', 'es'] });
+
+        // Definir relaciones
+        model.hasMany(models.Guild, { as: 'guilds', foreignKey: 'ownerId' });
+
+        // Definir cualquier método personalizado para la instancia
+        model.prototype.getNameAndAge = function () {
+            return this.name + ', ' + this.age;
+        };
+    }
+```
+
+## usage
+
+Para usar el modelo en un comando solo necesitas obtenerlo desde `framework.database.models` y utilizarlo.
+
+```ts
+import { Command, CommandParameters, ZumitoFramework, CommandType } from "zumito-framework";
+
+export class CommandName extends Command {
+
+    execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): void {
+        let user = framework.database.models.User.findOne({ where: { username: 'JhonDoe' } }).then((err, user) => {
+            user.username = 'JhonDoe2';
+            user.save();
+        });
+    }
+
+}
+```
+
+Puedes encontrar más información sobre el uso en la página del paquete [canario](https://www.npmjs.com/package/canario).

--- a/src/content/docs/es/guides/route.mdx
+++ b/src/content/docs/es/guides/route.mdx
@@ -1,0 +1,79 @@
+---
+title: Crear ruta
+description: Guía rápida para crear rutas con zumito-framework.
+---
+
+import { Icon } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
+import CreateProject from '../../../components/wizard/createProject.svelte';
+import { Steps } from '@astrojs/starlight/components';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Esta guía te ayudará a comenzar rápidamente a desarrollar un nuevo bot usando zumito-framework.
+
+## What's a route?
+
+Una ruta es un endpoint web que permite a usuarios u otros programas interactuar y obtener información de tu bot.
+
+## How can i create a route?
+
+<Steps>
+  1. Crear nueva ruta
+      <Tabs>
+        <TabItem label="Command Line" icon="cli">
+      ```bash
+      npx zumito-cli create route
+      ```
+        </TabItem>
+        <TabItem label="Wizard" icon="wizard">
+          Work in progress...
+        </TabItem>
+      </Tabs>
+
+  2. Edita tu archivo
+      :::note
+        Encontrarás el nuevo archivo de ruta en `/src/modules/<YourModule>/routes`
+      :::
+      Encontrarás un método como este:
+      ```ts
+      execute(req, res) {
+
+      }
+      ```
+      Aquí puedes ejecutar el código de tu ruta. Los parámetros req y res coinciden con los [parámetros de Express](https://expressjs.com/en/guide/routing.html)
+
+</Steps>
+
+## Quick tips
+
+:::tip[Redirects]
+    puedes enviar una redirección con:
+    ```ts
+    res.redirect(`https://framework.zumito.dev`);
+    ```
+:::
+
+
+## Next steps
+
+Una vez configurado el proyecto puedes comenzar a crear un módulo para tu bot.
+Aquí tienes una lista de cosas que podrías hacer:
+<LinkCard
+  title="Create a command"
+  description="Start creating commands for your bot"
+  href="/guides/command"
+/>
+
+<CardGrid>
+  <LinkCard
+    title="Listen to an event"
+    description="Execute a piece of code when some event ocurs"
+    href="/guides/event"
+  />
+  <LinkCard
+    title="Create database model"
+    description="Write a database model to store and retrieve data"
+    href="/guides/model"
+  />
+</CardGrid>

--- a/src/content/docs/es/guides/services/invite-url-generator.mdx
+++ b/src/content/docs/es/guides/services/invite-url-generator.mdx
@@ -1,0 +1,22 @@
+---
+title: Generador de URL de invitación
+description: Utiliza el servicio InviteUrlGenerator para crear enlaces de invitación para tu bot.
+---
+
+El servicio `InviteUrlGenerator` proporciona una ayuda para crear fácilmente la URL OAuth2 de Discord necesaria para invitar tu bot a un servidor.
+
+Primero obtén la instancia del servicio desde el `ServiceContainer`:
+```ts
+import { ServiceContainer } from 'zumito-framework';
+import { InviteUrlGenerator } from 'zumito-framework';
+
+const inviteGenerator = ServiceContainer.getService(InviteUrlGenerator);
+```
+
+Una vez tengas el servicio puedes llamar a `generateBotInviteUrl(clientId?, permissions?)`.
+Ambos parámetros son opcionales; si omites `clientId` se usará el valor de `process.env.DISCORD_CLIENT_ID`. Si no se proporcionan `permissions` el valor por defecto es `0`.
+
+```ts
+const url = inviteGenerator.generateBotInviteUrl();
+// https://discord.com/api/oauth2/authorize?client_id=...&permissions=0&scope=bot
+```

--- a/src/content/docs/es/guides/services/translator.mdx
+++ b/src/content/docs/es/guides/services/translator.mdx
@@ -1,0 +1,91 @@
+---
+title: Servicio de traducciones
+description: Guía rápida para obtener cadenas en diferentes idiomas.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import { FileTree } from '@astrojs/starlight/components';
+
+Zumito incluye de forma predeterminada un sistema de localización.
+
+## Define translations
+El primer paso para utilizar el sistema de traducciones es registrar algunos textos. Para ello solo crea un archivo json en la carpeta `translations` de tu bundle con el nombre del idioma en formato <a href="https://en.wikipedia.org/wiki/ISO_639-1">ISO 639-1</a>
+
+Examples:
+<FileTree>
+- src
+  - modules
+    - example
+        - translations
+            - en.json
+            - es.json
+            - exampleSubkey2
+                - en.json
+                - es.json
+</FileTree>
+
+Después en el json simplemente escribe tus textos con una clave.
+
+en.json
+```json
+{
+    "examplePhrase1": "This is an example phrase",
+    "exampleSubkey1": {
+        "examplePhrase2: "This is an example phrase with a subkey"
+    }
+}
+```
+
+es.json
+```json
+{
+    "examplePhrase1": "Esta es una frase de ejemplo",
+    "exampleSubkey1": {
+        "examplePhrase2: "Esta es una frase de ejemplo con una subclave"
+    }
+}
+```
+
+exampleSubkey2/en.json
+```json
+{
+    "examplePhrase3": "This is an example phrase within a subfolder"
+}
+```
+
+## Obtain translations
+Ahora que hemos establecido algunas traducciones obtengamos el texto traducido.
+Para ello primero necesitamos importar el servicio de traducciones. Primero importamos el ServiceContainer así:
+```ts
+import { ServiceContainer } from 'zumito-framework';
+```
+
+y luego en nuestro código obtenemos el servicio Translator:
+```ts
+const translator = ServiceContainer.getService('TranslationManager');
+```
+
+Y obtenemos los textos traducidos por la clave y el idioma:
+```ts
+translator.get('examplePhrase1', 'en'); // returns "This is an example phrase"
+translator.get('exampleSubkey1.examplePhrase1', 'es'); // returns "Esta es una frase de ejemplo con una subclave"
+translator.get('exampleSubkey2.examplePhrase3', 'en'); // returns "This is an example phrase within a subfolder"
+```
+
+## Translation variables
+Algunas traducciones necesitan tener texto variable, como información del usuario u otros datos.
+Puedes definir un texto con una o múltiples variables encerradas entre llaves:
+
+en.json
+```json
+{
+    "welcome": "hi {user}, have a nice day!",
+}
+```
+
+luego puedes obtener la traducción así:
+```ts
+translator.get('welcome', 'en', {
+    user: "Zumito"
+}); // returns "hi Zumito, have a nice day!"
+```


### PR DESCRIPTION
## Summary
- provide Spanish versions for all remaining guides

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500bad3868832fbefb85d20ea4d8bd