### PR TITLE
Fix component import path in Spanish route guide

### DIFF
--- a/src/content/docs/es/guides/route.mdx
+++ b/src/content/docs/es/guides/route.mdx
@@ -6,7 +6,7 @@ description: Guía rápida para crear rutas con zumito-framework.
 import { Icon } from '@astrojs/starlight/components';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import { Aside } from '@astrojs/starlight/components';
-import CreateProject from '../../../components/wizard/createProject.svelte';
+import CreateProject from '../../../../components/wizard/createProject.svelte';
 import { Steps } from '@astrojs/starlight/components';
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 


### PR DESCRIPTION
## Summary
- correct relative path for CreateProject in Spanish route guide

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68500d6fae28832fa617ee23ef4ddcc6