### PR TITLE
docs: add guide index

### DIFF
--- a/src/content/docs/guides/index.mdx
+++ b/src/content/docs/guides/index.mdx
@@ -1,6 +1,26 @@
 ---
-title: Guidex index
+title: Guides index
 description: An index of guides on zumito docs
 topic: guides
 ---
+
+Explore the available guides below to get the most out of Zumito:
+
+## Core guides
+
+- [Quick start guide](/guides/start) – A quick start guide to get you up and running with the bot.
+- [CLI](/guides/cli) – A comprehensive guide to the zumito-cli commands.
+- [Create command](/guides/command) – A quick guide on how to create a command.
+- [Listen to an event](/guides/event) – A quick guide on how to listen to events.
+- [Update bot status](/guides/bot-status) – A quick guide on how to update bot status.
+- [Environment variables](/guides/env) – Guide for env variables.
+- [Database](/guides/database) – A guide to the database.
+- [Prefix Resolver](/guides/prefix-resolver) – A guide to the prefix resolver.
+- [Create Route](/guides/route) – A quick guide for creating routes with zumito-framework.
+- [Zumito Config](/guides/zumito-config) – A guide to the `zumito.config.ts` file.
+
+## Services
+
+- [Invite URL generator](/guides/services/invite-url-generator) – Use the InviteUrlGenerator service to create links for inviting your bot.
+- [Translation service](/guides/services/translator) – Quick guide on how to get strings in different languages.
 


### PR DESCRIPTION
## Summary
- list available guides with descriptions and quick links

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890a5483350832f93407d60cf4e7e5b