### PR TITLE
feat: refine home page intro

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Welcome to Zumito Docs
 description: Get started building your next discord bot.
 template: splash
 hero:
-  tagline: Congrats on setting up a new Starlight project!
+  tagline: Zumito Framework te ayuda a crear bots de Discord rápidamente. Explora las guías esenciales para comenzar.
   image:
     file: ../../../public/zumito-hi.png
   actions:


### PR DESCRIPTION
## Summary
- translate homepage tagline to Spanish and drop extra quick links, keeping only the original quick start guide

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890a4e9cbc4832f906fd7eda7c2eabc