### PR TITLE
docs: add What's New section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import svelte from "@astrojs/svelte";
 import fs from 'fs';
 
 const sidebar = [
+    { label: "What's New", link: '/whats-new' },
     { label: 'Quick Start', link: '/guides/start' },
     {
         label: 'Getting Started',

--- a/src/components/WhatsNew.astro
+++ b/src/components/WhatsNew.astro
@@ -1,0 +1,48 @@
+---
+const headers = { 'User-Agent': 'zumito-docs' };
+let items = null;
+try {
+  const releaseResponse = await fetch(
+    'https://api.github.com/repos/ZumitoTeam/zumito-framework/releases?per_page=5',
+    { headers }
+  );
+  const releases = await releaseResponse.json();
+  items = await Promise.all(
+    releases.map(async (release, index) => {
+      const prevTag = releases[index + 1]?.tag_name;
+      let commits = [];
+      if (prevTag) {
+        const compareRes = await fetch(
+          `https://api.github.com/repos/ZumitoTeam/zumito-framework/compare/${prevTag}...${release.tag_name}`,
+          { headers }
+        );
+        const compareData = await compareRes.json();
+        commits = compareData.commits || [];
+      }
+      return { release, commits };
+    })
+  );
+} catch (error) {
+  console.error('Failed to load release information', error);
+}
+---
+{items ? (
+  items.map(({ release, commits }) => (
+    <section>
+      <h2>{release.tag_name}</h2>
+      {release.body && <p>{release.body.split('\n')[0]}</p>}
+      {commits.length > 0 && (
+        <ul>
+          {commits.map((commit) => (
+            <li>
+              <a href={commit.html_url}>{commit.commit.message.split('\n')[0]}</a>
+            </li>
+          ))}
+        </ul>
+      )}
+      <p><a href={release.html_url}>See full release notes</a></p>
+    </section>
+  ))
+) : (
+  <p>Unable to load release information at this time.</p>
+)}

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -11,6 +11,10 @@ hero:
       link: /guides/start
       icon: right-arrow
       variant: primary
+    - text: What's New
+      link: /whats-new
+      icon: open-book
+      variant: secondary
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/whats-new.mdx
+++ b/src/content/docs/whats-new.mdx
@@ -1,0 +1,10 @@
+---
+title: What's New
+description: Recent changes and improvements to the Zumito Framework.
+---
+
+import WhatsNew from '../../components/WhatsNew.astro';
+
+# What's New
+
+<WhatsNew />


### PR DESCRIPTION
## Summary
- link to new "What's New" page from landing hero and sidebar
- autogenerate release summaries from zumito-framework commits

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ace3052828832f99147371c6788545